### PR TITLE
Update code style config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,6 @@ trim_trailing_whitespace = false
 
 [*.{yml,yaml}]
 indent_size = 2
+
+[*.json]
+indent_size = 2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,8 @@
 on: [push]
-name: Lint
+name: lint
 jobs:
-  ecs:
-    name: Easy Coding Standard
+  lint:
+    name: Linting
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -18,6 +18,12 @@ jobs:
         uses: ramsey/composer-install@v1
       - name: Easy Coding Standard Action
         run: ./vendor/bin/ecs check --fix
+      - name: PHP-CS-Fixer Action
+        run: ./vendor/bin/php-cs-fixer fix
+      - name: Rector Action
+        run: ./vendor/bin/rector process
+      - name: TLint Action
+        run: ./vendor/bin/tlint lint
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+use Chiiya\CodeStyle\Config;
+use PhpCsFixer\Finder;
+use PhpCsFixerCustomFixers\Fixer\CommentedOutFunctionFixer;
+
+require __DIR__.'/vendor/autoload.php';
+
+return (new Config)
+    ->setFinder(Finder::create()->in([
+        __DIR__.'/src',
+        __DIR__.'/config',
+        __DIR__.'/tests',
+    ]))
+    ->setRules([
+        '@Chiiya' => true,
+        '@Chiiya:risky' => true,
+        CommentedOutFunctionFixer::name() => [
+            'functions' => ['dd', 'dump', 'ini_set', 'print_r', 'var_dump', 'var_export'],
+        ],
+    ])
+    ->setRiskyAllowed(true);

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Laravel Remote Template
 
 [![Latest Version](https://img.shields.io/github/release/schnoop/laravel-remote-template.svg?style=flat-square)](https://github.com/schnoop/laravel-remote-template/releases)
-[![GitHub Code Style Action Status](https://img.shields.io/github/workflow/status/schnoop/laravel-remote-template/Lint?label=code%20style)](https://github.com/schnoop/laravel-remote-template/actions?query=workflow%3A"Lint"+branch%3Amaster)
+[![GitHub Code Style Action Status](https://img.shields.io/github/workflow/status/schnoop/laravel-remote-template/lint?label=code%20style)](https://github.com/schnoop/laravel-remote-template/actions?query=workflow%3Alint+branch%3Adevelop)
 [![Total Downloads](https://img.shields.io/packagist/dt/schnoop/laravel-remote-template.svg?style=flat-square)](https://packagist.org/packages/schnoop/laravel-remote-template)
 
 `laravel-remote-template` is a package for fetching blade templates from a remote URL.

--- a/composer.json
+++ b/composer.json
@@ -17,15 +17,16 @@
     }
   ],
   "require": {
-    "php": "^8.0.2",
+    "php": "^8.1",
+    "illuminate/contracts": "^9.0",
     "laravel/framework": "^9.2",
     "guzzlehttp/guzzle": "^7.2"
   },
   "require-dev": {
-    "chiiya/code-style-php": "^1.3",
-    "mockery/mockery": "^1.4.4",
-    "orchestra/testbench": "^7.0",
-    "phpunit/phpunit": "^9.5.10"
+    "chiiya/laravel-code-style": "^1.7",
+    "mockery/mockery": "^1.5",
+    "orchestra/testbench": "^7.1",
+    "phpunit/phpunit": "^9.5"
   },
   "autoload": {
     "psr-4": {
@@ -40,7 +41,11 @@
   "config": {
     "preferred-install": "dist",
     "sort-packages": true,
-    "optimize-autoloader": true
+    "optimize-autoloader": true,
+    "allow-plugins": {
+      "phpro/grumphp": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   },
   "scripts": {
     "prepare": [
@@ -50,8 +55,11 @@
       "@composer run prepare",
       "@php vendor/bin/phpunit -c ./ --color"
     ],
-    "post-autoload-dump": [
-      "@php vendor/bin/testbench package:discover --ansi"
+    "lint": [
+      "@php vendor/bin/ecs check --fix",
+      "@php vendor/bin/php-cs-fixer fix",
+      "@php vendor/bin/rector process",
+      "@php vendor/bin/tlint lint"
     ]
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,9 @@
     "prepare": [
       "@composer run post-autoload-dump"
     ],
+    "post-autoload-dump": [
+      "@php ./vendor/bin/testbench package:discover --ansi"
+    ],
     "test": [
       "@composer run prepare",
       "@php vendor/bin/phpunit -c ./ --color"

--- a/config/remote-view.php
+++ b/config/remote-view.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 return [
     'guzzle-config' => [
         'allow_redirects' => false,

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -14,19 +14,12 @@ grumphp:
   fixer:
     enabled: true
     fix_by_default: true
-  extensions: []
   tasks:
     composer: ~
-    git_blacklist:
-      keywords:
-        - ' dd('
-        - 'dump('
-        - 'die;'
-        - 'exit;'
-        - 'ini_set'
-        - 'error_reporting'
-        - 'set_time_limit'
-      whitelist_patterns:
-        - /^(?!_ide_helper\.php)/
-    ecs:
-      config: ecs.php
+    phpcsfixer:
+      config: '.php-cs-fixer.dist.php'
+    ecs: ~
+    rector: ~
+    tlint: ~
+  extensions:
+    - Chiiya\LaravelCodeStyle\GrumPHPExtensionLoader

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,9 +22,4 @@
             <directory>src/</directory>
         </whitelist>
     </filter>
-    <php>
-        <server name="APP_ENV" value="testing"/>
-        <server name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
-        <server name="RAY_ENABLED" value="(true)"/>
-    </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         verbose="true">
+    <testsuites>
+        <testsuite name="Package">
+            <directory suffix="Test.php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>src/</directory>
+        </whitelist>
+    </filter>
+    <php>
+        <server name="APP_ENV" value="testing"/>
+        <server name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
+        <server name="RAY_ENABLED" value="(true)"/>
+    </php>
+</phpunit>

--- a/rector.php
+++ b/rector.php
@@ -1,15 +1,16 @@
 <?php declare(strict_types=1);
 
 use Chiiya\CodeStyle\CodeStyle;
+use Rector\Core\Configuration\Option;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\EasyCodingStandard\ValueObject\Option;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(CodeStyle::ECS);
     $parameters = $containerConfigurator->parameters();
     $parameters->set(Option::PATHS, [
         __DIR__.'/src',
         __DIR__.'/config',
         __DIR__.'/tests',
     ]);
+    $parameters->set(Option::AUTO_IMPORT_NAMES, true);
+    $containerConfigurator->import(CodeStyle::RECTOR);
 };

--- a/src/Exceptions/IgnoredUrlSuffixException.php
+++ b/src/Exceptions/IgnoredUrlSuffixException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Schnoop\RemoteTemplate\Exceptions;
 
 use Exception;

--- a/src/Exceptions/RemoteHostNotConfiguredException.php
+++ b/src/Exceptions/RemoteHostNotConfiguredException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Schnoop\RemoteTemplate\Exceptions;
 
 use Exception;

--- a/src/Exceptions/RemoteTemplateNotFoundException.php
+++ b/src/Exceptions/RemoteTemplateNotFoundException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Schnoop\RemoteTemplate\Exceptions;
 
 use Exception;

--- a/src/Exceptions/UrlIsForbiddenException.php
+++ b/src/Exceptions/UrlIsForbiddenException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Schnoop\RemoteTemplate\Exceptions;
 
 use Exception;

--- a/src/RemoteTemplateServiceProvider.php
+++ b/src/RemoteTemplateServiceProvider.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Schnoop\RemoteTemplate;
 
 use GuzzleHttp\Client;
@@ -33,11 +31,8 @@ class RemoteTemplateServiceProvider extends ViewServiceProvider
     public function register(): void
     {
         $this->registerViewFinder();
-
         $this->registerFactory();
-
         $this->registerBladeCompiler();
-
         $this->registerEngineResolver();
     }
 
@@ -52,7 +47,7 @@ class RemoteTemplateServiceProvider extends ViewServiceProvider
             return new RemoteTemplateFinder(
                 $app['files'],
                 $app['config'],
-                new Client($app['config']['remote-view.guzzle-config'])
+                new Client($app['config']['remote-view.guzzle-config']),
             );
         });
 
@@ -62,8 +57,8 @@ class RemoteTemplateServiceProvider extends ViewServiceProvider
                 $app['files'],
                 $app['config']['view.paths'],
                 $app['remoteview.finder'],
-                null
-            )
+                null,
+            ),
         );
     }
 

--- a/src/View/Factory.php
+++ b/src/View/Factory.php
@@ -1,14 +1,13 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Schnoop\RemoteTemplate\View;
 
 use Illuminate\Support\Str;
+use Illuminate\View\Factory as LaravelFactory;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 
-class Factory extends \Illuminate\View\Factory
+class Factory extends LaravelFactory
 {
     /**
      * Normalize a view name.
@@ -22,7 +21,7 @@ class Factory extends \Illuminate\View\Factory
     {
         $delimiter = $this->container->get('config')->get('remote-view.remote-delimiter');
 
-        if (Str::startsWith($name, $delimiter) === false) {
+        if (! Str::startsWith($name, $delimiter)) {
             return parent::normalizeName($name);
         }
 

--- a/src/View/FileViewFinder.php
+++ b/src/View/FileViewFinder.php
@@ -1,28 +1,25 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Schnoop\RemoteTemplate\View;
 
 use GuzzleHttp\Exception\GuzzleException;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\FileViewFinder as LaravelFileViewFinder;
 use Schnoop\RemoteTemplate\Exceptions\IgnoredUrlSuffixException;
 use Schnoop\RemoteTemplate\Exceptions\RemoteHostNotConfiguredException;
 use Schnoop\RemoteTemplate\Exceptions\RemoteTemplateNotFoundException;
 use Schnoop\RemoteTemplate\Exceptions\UrlIsForbiddenException;
 
-class FileViewFinder extends \Illuminate\View\FileViewFinder
+class FileViewFinder extends LaravelFileViewFinder
 {
     /**
      * Create a new file view loader instance.
-     *
-     * @param RemoteTemplateFinder $remoteView
      */
     public function __construct(
         Filesystem $files,
         array $paths,
         private RemoteTemplateFinder $remoteView,
-        ?array $extensions = null
+        ?array $extensions = null,
     ) {
         parent::__construct($files, $paths, $extensions);
     }
@@ -44,7 +41,7 @@ class FileViewFinder extends \Illuminate\View\FileViewFinder
             return $this->views[$name];
         }
 
-        if ($this->remoteView->hasRemoteInformation($name = trim($name)) === true) {
+        if ($this->remoteView->hasRemoteInformation($name = trim($name))) {
             return $this->views[$name] = $this->remoteView->findRemotePathView($name);
         }
 

--- a/src/View/RemoteTemplateFinder.php
+++ b/src/View/RemoteTemplateFinder.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Http\Response as IlluminateResponse;
 use Illuminate\Support\Str;
 use Illuminate\View\ViewFinderInterface;
 use InvalidArgumentException;
@@ -100,7 +101,7 @@ class RemoteTemplateFinder
 
         if ($content instanceof Response) {
             $content = $content->getBody()->getContents();
-        } elseif ($content instanceof \Illuminate\Http\Response) {
+        } elseif ($content instanceof IlluminateResponse) {
             $content = (string) $content->getContent();
         }
         $this->files->put($path, $content);
@@ -117,7 +118,7 @@ class RemoteTemplateFinder
     public function fetchContentFromRemoteHost(
         string $url,
         array $remoteHost,
-    ): \Illuminate\Http\Response|Response|ResponseInterface {
+    ): IlluminateResponse|Response|ResponseInterface {
         $options = [
             'http_errors' => false,
         ];
@@ -281,7 +282,7 @@ class RemoteTemplateFinder
     protected function callResponseHandler(
         ResponseInterface $result,
         array $remoteHost,
-    ): \Illuminate\Http\Response|Response|ResponseInterface {
+    ): IlluminateResponse|Response|ResponseInterface {
         if (isset($this->handler[$result->getStatusCode()])
             && is_callable($this->handler[$result->getStatusCode()])
         ) {

--- a/src/View/RemoteTemplateFinder.php
+++ b/src/View/RemoteTemplateFinder.php
@@ -23,8 +23,8 @@ use Schnoop\RemoteTemplate\Exceptions\UrlIsForbiddenException;
 class RemoteTemplateFinder
 {
     protected string $remotePathDelimiter;
-    protected ?Closure $templateUrlCallback;
-    protected ?Closure $viewFilenameCallback;
+    protected ?Closure $templateUrlCallback = null;
+    protected ?Closure $viewFilenameCallback = null;
 
     /** @var Closure[] */
     protected array $handler;
@@ -37,7 +37,7 @@ class RemoteTemplateFinder
         protected Repository $config,
         protected Client $client,
     ) {
-        $this->remotePathDelimiter = config('remote-view.remote-delimiter');
+        $this->remotePathDelimiter = config('remote-view.remote-delimiter', 'remote:');
     }
 
     /**

--- a/src/View/RemoteTemplateFinder.php
+++ b/src/View/RemoteTemplateFinder.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Schnoop\RemoteTemplate\View;
 
 use Closure;
@@ -23,39 +21,22 @@ use Schnoop\RemoteTemplate\Exceptions\UrlIsForbiddenException;
 
 class RemoteTemplateFinder
 {
-    /**
-     * @var string
-     */
-    protected $remotePathDelimiter;
+    protected string $remotePathDelimiter;
+    protected ?Closure $templateUrlCallback;
+    protected ?Closure $viewFilenameCallback;
 
-    /**
-     * @var Closure[]
-     */
+    /** @var Closure[] */
     protected array $handler;
 
     /**
-     * @var Closure
-     */
-    protected $templateUrlCallback;
-
-    /**
-     * @var Closure
-     */
-    protected $viewFilenameCallback;
-
-    /**
      * Create a new file view loader instance.
-     *
-     * @param Filesystem $files
-     * @param Repository $config
-     * @param Client $client
      */
     public function __construct(
         protected Filesystem $files,
         protected Repository $config,
-        protected Client $client
+        protected Client $client,
     ) {
-        $this->remotePathDelimiter = $this->config->get('remote-view.remote-delimiter');
+        $this->remotePathDelimiter = config('remote-view.remote-delimiter');
     }
 
     /**
@@ -84,7 +65,8 @@ class RemoteTemplateFinder
         $name = trim(Str::replaceFirst($this->remotePathDelimiter, '', $name));
 
         $namespace = 'default';
-        if ($this->hasNamespace($name) === true) {
+
+        if ($this->hasNamespace($name)) {
             $elements = $this->parseRemoteNamespaceSegments($name);
             $namespace = $elements[0];
             $name = $elements[1];
@@ -93,12 +75,12 @@ class RemoteTemplateFinder
         $remoteHost = $this->getRemoteHost($namespace);
 
         // Check if URL suffix is ignored
-        if ($this->urlHasIgnoredSuffix($name, $remoteHost) === true) {
+        if ($this->urlHasIgnoredSuffix($name, $remoteHost)) {
             throw new IgnoredUrlSuffixException('URL # '.$name.' has an ignored suffix.');
         }
 
         // Check if URL is forbidden.
-        if ($this->isForbiddenUrl($name, $remoteHost) === true) {
+        if ($this->isForbiddenUrl($name, $remoteHost)) {
             throw new UrlIsForbiddenException('URL # '.$name.' is forbidden.', 404);
         }
 
@@ -107,14 +89,16 @@ class RemoteTemplateFinder
 
         $path = $this->getViewFolder($namespace);
         $path .= $this->getViewFilename($url);
-        if ($remoteHost['cache'] === true && $this->files->exists($path) === true) {
+
+        if ($remoteHost['cache'] === true && $this->files->exists($path)) {
             return $path;
         }
 
         $url = rtrim($remoteHost['host'], '/').'/'.ltrim($url, '/');
 
         $content = $this->fetchContentFromRemoteHost($url, $remoteHost);
-        if ($content instanceof Response === true) {
+
+        if ($content instanceof Response) {
             $content = $content->getBody()->getContents();
         } elseif ($content instanceof \Illuminate\Http\Response) {
             $content = (string) $content->getContent();
@@ -132,12 +116,13 @@ class RemoteTemplateFinder
      */
     public function fetchContentFromRemoteHost(
         string $url,
-        array $remoteHost
+        array $remoteHost,
     ): \Illuminate\Http\Response|Response|ResponseInterface {
         $options = [
             'http_errors' => false,
         ];
-        if (isset($remoteHost['request_options']) === true) {
+
+        if (isset($remoteHost['request_options'])) {
             $options = array_merge($options, $remoteHost['request_options']);
         }
 
@@ -145,7 +130,7 @@ class RemoteTemplateFinder
             $result = $this->client->get($url, $options);
 
             return $this->callResponseHandler($result, $remoteHost);
-        } catch (Exception $e) {
+        } catch (Exception) {
             throw new RemoteTemplateNotFoundException($url, 404);
         }
     }
@@ -183,7 +168,7 @@ class RemoteTemplateFinder
     {
         try {
             $this->parseRemoteNamespaceSegments($name);
-        } catch (Exception $e) {
+        } catch (Exception) {
             return false;
         }
 
@@ -198,7 +183,8 @@ class RemoteTemplateFinder
     protected function parseRemoteNamespaceSegments(string $name): array
     {
         $segments = explode(ViewFinderInterface::HINT_PATH_DELIMITER, $name);
-        if (\count($segments) < 2) {
+
+        if (count($segments) < 2) {
             throw new InvalidArgumentException("View [{$name}] has an invalid name.");
         }
 
@@ -213,9 +199,10 @@ class RemoteTemplateFinder
     protected function getRemoteHost(string $namespace): array
     {
         $config = $this->config->get('remote-view.hosts');
-        if (isset($config[$namespace]) === false) {
+
+        if (! isset($config[$namespace])) {
             throw new RemoteHostNotConfiguredException(
-                'No remote host configured for namespace # '.$namespace.'. Please check your remote-view.php config file.'
+                'No remote host configured for namespace # '.$namespace.'. Please check your remote-view.php config file.',
             );
         }
 
@@ -231,11 +218,12 @@ class RemoteTemplateFinder
         $pathInfo = pathinfo($parsedUrl, PATHINFO_EXTENSION);
 
         $ignoreUrlSuffix = $this->config->get('remote-view.ignore-url-suffix');
-        if (isset($remoteHost['ignore-url-suffix']) === true && \is_array($remoteHost['ignore-url-suffix']) === true) {
+
+        if (isset($remoteHost['ignore-url-suffix']) && is_array($remoteHost['ignore-url-suffix'])) {
             $ignoreUrlSuffix = array_merge($ignoreUrlSuffix, $remoteHost['ignore-url-suffix']);
         }
 
-        return \in_array($pathInfo, $ignoreUrlSuffix, true);
+        return in_array($pathInfo, $ignoreUrlSuffix, true);
     }
 
     /**
@@ -244,9 +232,11 @@ class RemoteTemplateFinder
     protected function getTemplateUrlForIdentifier(string $identifier, array $remoteHost): string
     {
         $route = $identifier;
-        if (isset($remoteHost['mapping'][$identifier]) === true) {
+
+        if (isset($remoteHost['mapping'][$identifier])) {
             $route = $remoteHost['mapping'][$identifier];
         }
+
         if (mb_strpos($route, '/') > 0) {
             return '/'.$route;
         }
@@ -260,7 +250,7 @@ class RemoteTemplateFinder
     protected function callModifyTemplateUrlCallback(string $url): string
     {
         if ($this->templateUrlCallback !== null
-            && \is_callable($this->templateUrlCallback) === true
+            && is_callable($this->templateUrlCallback)
         ) {
             return ($this->templateUrlCallback)($url);
         }
@@ -277,10 +267,9 @@ class RemoteTemplateFinder
     {
         $path = $this->config->get('remote-view.view-folder');
         $path = rtrim($path, '/').'/'.$namespace.'/';
-        if (is_dir($path) === false) {
-            if (! mkdir($path, 0777, true) && ! is_dir($path)) {
-                throw new RuntimeException(sprintf('Directory "%s" was not created', $path));
-            }
+
+        if (! is_dir($path) && (! mkdir($path, 0o777, true) && ! is_dir($path))) {
+            throw new RuntimeException(sprintf('Directory "%s" was not created', $path));
         }
 
         return $path;
@@ -291,12 +280,12 @@ class RemoteTemplateFinder
      */
     protected function callResponseHandler(
         ResponseInterface $result,
-        array $remoteHost
+        array $remoteHost,
     ): \Illuminate\Http\Response|Response|ResponseInterface {
-        if (isset($this->handler[$result->getStatusCode()]) === true
-            && \is_callable($this->handler[$result->getStatusCode()]) === true
+        if (isset($this->handler[$result->getStatusCode()])
+            && is_callable($this->handler[$result->getStatusCode()])
         ) {
-            return \call_user_func($this->handler[$result->getStatusCode()], $result, $remoteHost, $this);
+            return call_user_func($this->handler[$result->getStatusCode()], $result, $remoteHost, $this);
         }
 
         return $result;
@@ -305,7 +294,7 @@ class RemoteTemplateFinder
     protected function getViewFilename(string $url): string
     {
         if ($this->viewFilenameCallback !== null
-            && \is_callable($this->viewFilenameCallback) === true
+            && is_callable($this->viewFilenameCallback)
         ) {
             return ($this->viewFilenameCallback)($url);
         }
@@ -319,13 +308,14 @@ class RemoteTemplateFinder
     private function isForbiddenUrl(string $url, array $remoteHost): bool
     {
         $ignoreUrlSuffix = $this->config->get('remote-view.ignore-urls');
-        if (isset($remoteHost['ignore-urls']) === true && \is_array($remoteHost['ignore-urls']) === true) {
+
+        if (isset($remoteHost['ignore-urls']) && is_array($remoteHost['ignore-urls'])) {
             $ignoreUrlSuffix = array_merge($ignoreUrlSuffix, $remoteHost['ignore-urls']);
         }
 
         $parsedUrl = parse_url($url, PHP_URL_PATH);
 
-        return \in_array(pathinfo($parsedUrl, PATHINFO_DIRNAME), $ignoreUrlSuffix, true)
-            || \in_array(pathinfo($parsedUrl, PATHINFO_BASENAME), $ignoreUrlSuffix, true);
+        return in_array(pathinfo($parsedUrl, PATHINFO_DIRNAME), $ignoreUrlSuffix, true)
+            || in_array(pathinfo($parsedUrl, PATHINFO_BASENAME), $ignoreUrlSuffix, true);
     }
 }

--- a/tests/FeatureTest.php
+++ b/tests/FeatureTest.php
@@ -1,18 +1,47 @@
 <?php
 
-use Illuminate\Routing\Router;
+namespace Schnoop\RemoteTemplate\Tests;
 
-/**
- * Class FeatureTest.
- */
-class FeatureTest extends \Orchestra\Testbench\TestCase
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Response as IlluminateResponse;
+use Illuminate\Routing\Router;
+use Orchestra\Testbench\TestCase;
+use Schnoop\RemoteTemplate\View\RemoteTemplateFinder;
+
+class FeatureTest extends TestCase
 {
+    public function test_response_ok(): void
+    {
+        $crawler = $this->call('GET', 'web/200');
+        $crawler->assertStatus(200);
+    }
+
+    public function test_response_is500_if_domain_not_found(): void
+    {
+        $this->app['config']->set('remote-view.hosts.default.host', 'http://www.googlasdade.com');
+        $crawler = $this->call('GET', 'web/200');
+        $crawler->assertStatus(500);
+    }
+
+    public function test_response_handler_if_response_is404(): void
+    {
+        $this->app['config']->set('remote-view.hosts.default.host', 'http://www.google.com');
+        $this->app->make('remoteview.finder')->pushResponseHandler(
+            404,
+            fn (Response $result, array $config, RemoteTemplateFinder $service) => new IlluminateResponse(
+                'This content has been modified through a response handler.',
+                405,
+            ),
+        );
+        $crawler = $this->call('GET', 'web/404');
+        $crawler->assertSee('This content has been modified through a response handler.');
+    }
+
     /**
-     * @param \Illuminate\Foundation\Application $app
-     *
-     * @return array
+     * @param Application $app
      */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return ['Schnoop\RemoteTemplate\RemoteTemplateServiceProvider'];
     }
@@ -20,58 +49,25 @@ class FeatureTest extends \Orchestra\Testbench\TestCase
     /**
      * Define environment setup.
      *
-     * @param Illuminate\Foundation\Application $app
-     *
-     * @return void
+     * @param Application $app
      */
-    protected function getEnvironmentSetUp($app)
+    protected function getEnvironmentSetUp($app): void
     {
-        $app['config']->set('view.paths', [realpath(('tests/views'))]);
+        $app['config']->set('view.paths', [realpath('tests/views')]);
         $app['config']->set('remote-view.hosts.default.host', 'http://www.google.com');
         $router = $app['router'];
         $this->addWebRoutes($router);
     }
 
-    /**
-     * @param Router $router
-     */
-    protected function addWebRoutes(Router $router)
+    protected function addWebRoutes(Router $router): void
     {
         $router->get('web/200', [
             'as' => 'web.200',
-            'uses' => function () {
-                return view('200');
-            },
+            'uses' => fn () => view('200'),
         ]);
         $router->get('web/404', [
             'as' => 'web.404',
-            'uses' => function () {
-                return view('404');
-            },
+            'uses' => fn () => view('404'),
         ]);
-    }
-
-    public function testResponseOk()
-    {
-        $crawler = $this->call('GET', 'web/200');
-        $crawler->assertStatus(200);
-    }
-
-    public function testResponseIs500IfDomainNotFound()
-    {
-        $this->app['config']->set('remote-view.hosts.default.host', 'http://www.googlasdade.com');
-        $crawler = $this->call('GET', 'web/200');
-        $crawler->assertStatus(500);
-    }
-
-    public function testResponseHandlerIfResponseIs404()
-    {
-        $this->app['config']->set('remote-view.hosts.default.host', 'http://www.google.com');
-        $this->app->make('remoteview.finder')->pushResponseHandler(404,
-            function (\GuzzleHttp\Psr7\Response $result, array $config, \Schnoop\RemoteTemplate\View\RemoteTemplateFinder $service) {
-                return new \Illuminate\Http\Response('This content has been modified through a response handler.', 405);
-            });
-        $crawler = $this->call('GET', 'web/404');
-        $crawler->assertSee('This content has been modified through a response handler.');
     }
 }

--- a/tests/FileViewFinderTest.php
+++ b/tests/FileViewFinderTest.php
@@ -5,7 +5,7 @@ namespace Schnoop\RemoteTemplate\Tests;
 use Illuminate\Filesystem\Filesystem;
 use InvalidArgumentException;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
+use Orchestra\Testbench\TestCase;
 use Schnoop\RemoteTemplate\View\Factory;
 use Schnoop\RemoteTemplate\View\FileViewFinder;
 use Schnoop\RemoteTemplate\View\RemoteTemplateFinder;

--- a/tests/FileViewFinderTest.php
+++ b/tests/FileViewFinderTest.php
@@ -1,51 +1,41 @@
 <?php
 
+namespace Schnoop\RemoteTemplate\Tests;
+
+use Illuminate\Filesystem\Filesystem;
+use InvalidArgumentException;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Schnoop\RemoteTemplate\View\Factory;
+use Schnoop\RemoteTemplate\View\FileViewFinder;
 use Schnoop\RemoteTemplate\View\RemoteTemplateFinder;
 
-/**
- * Class FileViewFinderTest.
- */
 class FileViewFinderTest extends TestCase
 {
-    /**
-     * @var Factory
-     */
+    /** @var Factory */
     protected $instance;
 
-    public function testFindPathWithoutRemoteIdentifier()
+    public function test_find_path_without_remote_identifier(): void
     {
         $mock = m::mock(RemoteTemplateFinder::class);
         $mock->shouldReceive('hasRemoteInformation')->with('hurz')->andReturnFalse();
 
-        $this->instance = new \Schnoop\RemoteTemplate\View\FileViewFinder(
-            m::mock(\Illuminate\Filesystem\Filesystem::class),
-            [],
-            $mock,
-            []
-        );
+        $this->instance = new FileViewFinder(m::mock(Filesystem::class), [], $mock, []);
 
         $this->expectException(InvalidArgumentException::class);
         $this->instance->find('hurz');
     }
 
-    public function testFindPathWithRemoteIdentifier()
+    public function test_find_path_with_remote_identifier(): void
     {
         $mock = m::mock(RemoteTemplateFinder::class);
         $mock->shouldReceive('hasRemoteInformation')->with('remote:hurz')->andReturnTrue();
         $mock->shouldReceive('findRemotePathView')->with('remote:hurz')->andReturn('blubb');
         $mock->shouldNotHaveReceived('findRemotePathView');
 
-        $this->instance = new \Schnoop\RemoteTemplate\View\FileViewFinder(
-            m::mock(\Illuminate\Filesystem\Filesystem::class),
-            [],
-            $mock,
-            []
-        );
+        $this->instance = new FileViewFinder(m::mock(Filesystem::class), [], $mock, []);
 
-        $this->assertEquals('blubb', $this->instance->find('remote:hurz'));
-        $this->assertEquals('blubb', $this->instance->find('remote:hurz'));
+        $this->assertSame('blubb', $this->instance->find('remote:hurz'));
+        $this->assertSame('blubb', $this->instance->find('remote:hurz'));
     }
 }

--- a/tests/RemoteTemplateFinderTest.php
+++ b/tests/RemoteTemplateFinderTest.php
@@ -2,13 +2,14 @@
 
 namespace Schnoop\RemoteTemplate\Tests;
 
+use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\Response as IlluminateResponse;
 use Mockery as m;
-use PHPUnit\Framework\TestCase;
+use Orchestra\Testbench\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Schnoop\RemoteTemplate\Exceptions\IgnoredUrlSuffixException;
 use Schnoop\RemoteTemplate\Exceptions\RemoteHostNotConfiguredException;

--- a/tests/RemoteTemplateFinderTest.php
+++ b/tests/RemoteTemplateFinderTest.php
@@ -1,142 +1,107 @@
 <?php
 
+namespace Schnoop\RemoteTemplate\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Http\Response as IlluminateResponse;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 use Schnoop\RemoteTemplate\Exceptions\IgnoredUrlSuffixException;
 use Schnoop\RemoteTemplate\Exceptions\RemoteHostNotConfiguredException;
+use Schnoop\RemoteTemplate\Exceptions\RemoteTemplateNotFoundException;
 use Schnoop\RemoteTemplate\Exceptions\UrlIsForbiddenException;
 use Schnoop\RemoteTemplate\View\RemoteTemplateFinder;
 
-/**
- * Class RemoteTemplateFinderTest.
- */
 class RemoteTemplateFinderTest extends TestCase
 {
-    /**
-     * @var RemoteTemplateFinder
-     */
+    /** @var RemoteTemplateFinder */
     protected $instance;
 
-    /**
-     * @return m\MockInterface
-     */
-    private function getFilesystemMock()
-    {
-        return m::mock(\Illuminate\Filesystem\Filesystem::class);
-    }
-
-    /**
-     * @return m\MockInterface
-     */
-    private function getConfigMock()
-    {
-        $config = m::mock(\Illuminate\Contracts\Config\Repository::class);
-        $config->shouldReceive('get')->with('remote-view.remote-delimiter')->andReturn('remote:');
-
-        return $config;
-    }
-
-    public function testNoRemoteDelimiterFound()
+    public function test_no_remote_delimiter_found(): void
     {
         $this->instance = new RemoteTemplateFinder(
             $this->getFilesystemMock(),
             $this->getConfigMock(),
-            m::mock(\GuzzleHttp\Client::class)
+            m::mock(Client::class),
         );
 
         $this->assertFalse($this->instance->hasRemoteInformation('dasLamm'));
         $this->assertTrue($this->instance->hasRemoteInformation('remote:dasLamm'));
     }
 
-    public function testNoRemoteHostConfigured()
+    public function test_no_remote_host_configured(): void
     {
         $config = $this->getConfigMock();
         $config->shouldReceive('get')->with('remote-view.hosts')->andReturn([]);
-        $this->instance = new RemoteTemplateFinder(
-            $this->getFilesystemMock(),
-            $config,
-            m::mock(\GuzzleHttp\Client::class)
-        );
+        $this->instance = new RemoteTemplateFinder($this->getFilesystemMock(), $config, m::mock(Client::class));
 
         $this->expectException(RemoteHostNotConfiguredException::class);
-        $this->expectExceptionMessage('No remote host configured for namespace # default. Please check your remote-view.php config file.');
+        $this->expectExceptionMessage(
+            'No remote host configured for namespace # default. Please check your remote-view.php config file.',
+        );
         $this->instance->findRemotePathView('remote:dasLamm');
     }
 
-    public function testNoRemoteHostConfiguredForUsedNamespace()
+    public function test_no_remote_host_configured_for_used_namespace(): void
     {
         $hosts = [
-            'default' => [
-            ],
+            'default' => [],
         ];
 
         $config = $this->getConfigMock();
         $config->shouldReceive('get')->with('remote-view.hosts')->andReturn($hosts);
-        $this->instance = new RemoteTemplateFinder(
-            $this->getFilesystemMock(),
-            $config,
-            m::mock(\GuzzleHttp\Client::class)
-        );
+        $this->instance = new RemoteTemplateFinder($this->getFilesystemMock(), $config, m::mock(Client::class));
 
         $this->expectException(RemoteHostNotConfiguredException::class);
-        $this->expectExceptionMessage('No remote host configured for namespace # specific. Please check your remote-view.php config file.');
+        $this->expectExceptionMessage(
+            'No remote host configured for namespace # specific. Please check your remote-view.php config file.',
+        );
         $this->instance->findRemotePathView('remote:specific::dasLamm');
     }
 
-    public function testFileSuffixIsOnGlobalIgnoreList()
+    public function test_file_suffix_is_on_global_ignore_list(): void
     {
         $hosts = [
-            'default' => [
-            ],
+            'default' => [],
         ];
 
-        $ignoreFileList = [
-            'svg',
-        ];
+        $ignoreFileList = ['svg'];
 
         $config = $this->getConfigMock();
         $config->shouldReceive('get')->with('remote-view.hosts')->andReturn($hosts);
         $config->shouldReceive('get')->with('remote-view.ignore-url-suffix')->andReturn($ignoreFileList);
-        $this->instance = new RemoteTemplateFinder(
-            $this->getFilesystemMock(),
-            $config,
-            m::mock(\GuzzleHttp\Client::class)
-        );
+        $this->instance = new RemoteTemplateFinder($this->getFilesystemMock(), $config, m::mock(Client::class));
 
         $this->expectException(IgnoredUrlSuffixException::class);
         $this->expectExceptionMessage('URL # dasLamm.svg has an ignored suffix.');
         $this->instance->findRemotePathView('remote:dasLamm.svg');
     }
 
-    public function testFileSuffixIsOnHostIgnoreList()
+    public function test_file_suffix_is_on_host_ignore_list(): void
     {
         $hosts = [
             'default' => [
-                'ignore-url-suffix' => [
-                    'svg',
-                ],
+                'ignore-url-suffix' => ['svg'],
             ],
         ];
 
-        $ignoreFileList = [
-            'jpg',
-        ];
+        $ignoreFileList = ['jpg'];
 
         $config = $this->getConfigMock();
         $config->shouldReceive('get')->with('remote-view.hosts')->andReturn($hosts);
         $config->shouldReceive('get')->with('remote-view.ignore-url-suffix')->andReturn($ignoreFileList);
-        $this->instance = new RemoteTemplateFinder(
-            $this->getFilesystemMock(),
-            $config,
-            m::mock(\GuzzleHttp\Client::class)
-        );
+        $this->instance = new RemoteTemplateFinder($this->getFilesystemMock(), $config, m::mock(Client::class));
 
         $this->expectException(IgnoredUrlSuffixException::class);
         $this->expectExceptionMessage('URL # dasLamm.svg has an ignored suffix.');
         $this->instance->findRemotePathView('remote:dasLamm.svg');
     }
 
-    public function testCachingEnabledAndFileExistsForDefaultView()
+    public function test_caching_enabled_and_file_exists_for_default_view(): void
     {
         $hosts = [
             'default' => [
@@ -153,16 +118,12 @@ class RemoteTemplateFinderTest extends TestCase
         $fileSystemMock = $this->getFilesystemMock();
         $fileSystemMock->shouldReceive('exists')->with('tests/default/daslamm.blade.php')->andReturn(true);
 
-        $this->instance = new RemoteTemplateFinder(
-            $fileSystemMock,
-            $config,
-            m::mock(\GuzzleHttp\Client::class)
-        );
+        $this->instance = new RemoteTemplateFinder($fileSystemMock, $config, m::mock(Client::class));
 
-        $this->assertEquals('tests/default/daslamm.blade.php', $this->instance->findRemotePathView('remote:dasLamm'));
+        $this->assertSame('tests/default/daslamm.blade.php', $this->instance->findRemotePathView('remote:dasLamm'));
     }
 
-    public function testCachingEnabledAndFileExistsForNamespacedView()
+    public function test_caching_enabled_and_file_exists_for_namespaced_view(): void
     {
         $hosts = [
             'specific' => [
@@ -179,16 +140,15 @@ class RemoteTemplateFinderTest extends TestCase
         $fileSystemMock = $this->getFilesystemMock();
         $fileSystemMock->shouldReceive('exists')->with('tests/specific/daslamm.blade.php')->andReturn(true);
 
-        $this->instance = new RemoteTemplateFinder(
-            $fileSystemMock,
-            $config,
-            m::mock(\GuzzleHttp\Client::class)
-        );
+        $this->instance = new RemoteTemplateFinder($fileSystemMock, $config, m::mock(Client::class));
 
-        $this->assertEquals('tests/specific/daslamm.blade.php', $this->instance->findRemotePathView('remote:specific::dasLamm'));
+        $this->assertSame(
+            'tests/specific/daslamm.blade.php',
+            $this->instance->findRemotePathView('remote:specific::dasLamm'),
+        );
     }
 
-    public function testCachingIsDisabledAndFileExistsForNamespacedView()
+    public function test_caching_is_disabled_and_file_exists_for_namespaced_view(): void
     {
         $hosts = [
             'specific' => [
@@ -203,27 +163,26 @@ class RemoteTemplateFinderTest extends TestCase
         $config->shouldReceive('get')->with('remote-view.ignore-urls')->andReturn([]);
         $config->shouldReceive('get')->with('remote-view.view-folder')->andReturn('tests/');
 
-        $responseMock = m::mock(\Psr\Http\Message\ResponseInterface::class);
+        $responseMock = m::mock(ResponseInterface::class);
         $responseMock->shouldReceive('getStatusCode')->andReturn(200);
 
         $fileSystemMock = $this->getFilesystemMock();
         $fileSystemMock->shouldReceive('exists')->with('tests/specific/daslamm.blade.php')->andReturn(true);
         $fileSystemMock->shouldReceive('put')->with('tests/specific/daslamm.blade.php', $responseMock);
 
-        $clientMock = m::mock(\GuzzleHttp\Client::class);
+        $clientMock = m::mock(Client::class);
         $clientMock->shouldReceive('get')->with('http://foo.bar/dasLamm', ['http_errors' => false])
             ->andReturn($responseMock);
 
-        $this->instance = new RemoteTemplateFinder(
-            $fileSystemMock,
-            $config,
-            $clientMock
-        );
+        $this->instance = new RemoteTemplateFinder($fileSystemMock, $config, $clientMock);
 
-        $this->assertEquals('tests/specific/daslamm.blade.php', $this->instance->findRemotePathView('remote:specific::dasLamm'));
+        $this->assertSame(
+            'tests/specific/daslamm.blade.php',
+            $this->instance->findRemotePathView('remote:specific::dasLamm'),
+        );
     }
 
-    public function testCachingIsDisabledAndFileExistsForNamespacedViewWithIlluminateResponse()
+    public function test_caching_is_disabled_and_file_exists_for_namespaced_view_with_illuminate_response(): void
     {
         $hosts = [
             'specific' => [
@@ -238,7 +197,7 @@ class RemoteTemplateFinderTest extends TestCase
         $config->shouldReceive('get')->with('remote-view.ignore-urls')->andReturn([]);
         $config->shouldReceive('get')->with('remote-view.view-folder')->andReturn('tests/');
 
-        $responseMock = m::mock(\Psr\Http\Message\ResponseInterface::class);
+        $responseMock = m::mock(ResponseInterface::class);
         $responseMock->shouldReceive('getStatusCode')->andReturn(200);
         $responseMock->shouldReceive('getContent')->andReturn('MyContent');
 
@@ -246,20 +205,19 @@ class RemoteTemplateFinderTest extends TestCase
         $fileSystemMock->shouldReceive('exists')->with('tests/specific/daslamm.blade.php')->andReturn(true);
         $fileSystemMock->shouldReceive('put')->with('tests/specific/daslamm.blade.php', $responseMock);
 
-        $clientMock = m::mock(\GuzzleHttp\Client::class);
+        $clientMock = m::mock(Client::class);
         $clientMock->shouldReceive('get')->with('http://foo.bar/dasLamm', ['http_errors' => false])
             ->andReturn($responseMock);
 
-        $this->instance = new RemoteTemplateFinder(
-            $fileSystemMock,
-            $config,
-            $clientMock
-        );
+        $this->instance = new RemoteTemplateFinder($fileSystemMock, $config, $clientMock);
 
-        $this->assertEquals('tests/specific/daslamm.blade.php', $this->instance->findRemotePathView('remote:specific::dasLamm'));
+        $this->assertSame(
+            'tests/specific/daslamm.blade.php',
+            $this->instance->findRemotePathView('remote:specific::dasLamm'),
+        );
     }
 
-    public function testCachingIsDisabledAndFileExistsForNamespacedViewWithGuzzleResponse()
+    public function test_caching_is_disabled_and_file_exists_for_namespaced_view_with_guzzle_response(): void
     {
         $hosts = [
             'specific' => [
@@ -274,7 +232,7 @@ class RemoteTemplateFinderTest extends TestCase
         $config->shouldReceive('get')->with('remote-view.ignore-urls')->andReturn([]);
         $config->shouldReceive('get')->with('remote-view.view-folder')->andReturn('tests/');
 
-        $responseMock = m::mock(\GuzzleHttp\Psr7\Response::class);
+        $responseMock = m::mock(Response::class);
         $responseMock->shouldReceive('getStatusCode')->andReturn(200);
         $responseMock->shouldReceive('getBody->getContents')->andReturn('MyContent');
 
@@ -282,20 +240,19 @@ class RemoteTemplateFinderTest extends TestCase
         $fileSystemMock->shouldReceive('exists')->with('tests/specific/daslamm.blade.php')->andReturn(true);
         $fileSystemMock->shouldReceive('put')->with('tests/specific/daslamm.blade.php', 'MyContent');
 
-        $clientMock = m::mock(\GuzzleHttp\Client::class);
+        $clientMock = m::mock(Client::class);
         $clientMock->shouldReceive('get')->with('http://foo.bar/dasLamm', ['http_errors' => false])
             ->andReturn($responseMock);
 
-        $this->instance = new RemoteTemplateFinder(
-            $fileSystemMock,
-            $config,
-            $clientMock
-        );
+        $this->instance = new RemoteTemplateFinder($fileSystemMock, $config, $clientMock);
 
-        $this->assertEquals('tests/specific/daslamm.blade.php', $this->instance->findRemotePathView('remote:specific::dasLamm'));
+        $this->assertSame(
+            'tests/specific/daslamm.blade.php',
+            $this->instance->findRemotePathView('remote:specific::dasLamm'),
+        );
     }
 
-    public function testCachingIsDisabledAndFileNotExistsForNamespacedView()
+    public function test_caching_is_disabled_and_file_not_exists_for_namespaced_view(): void
     {
         $hosts = [
             'specific' => [
@@ -310,7 +267,7 @@ class RemoteTemplateFinderTest extends TestCase
         $config->shouldReceive('get')->with('remote-view.ignore-urls')->andReturn([]);
         $config->shouldReceive('get')->with('remote-view.view-folder')->andReturn('tests/');
 
-        $responseMock = m::mock(\GuzzleHttp\Psr7\Response::class);
+        $responseMock = m::mock(Response::class);
         $responseMock->shouldReceive('getStatusCode')->andReturn(200);
         $responseMock->shouldReceive('getBody->getContents')->andReturn('MyContent');
 
@@ -318,21 +275,17 @@ class RemoteTemplateFinderTest extends TestCase
         $fileSystemMock->shouldReceive('exists')->with('tests/specific/daslamm.blade.php')->andReturn(true);
         $fileSystemMock->shouldReceive('put')->with('tests/specific/daslamm.blade.php', 'MyContent');
 
-        $clientMock = m::mock(\GuzzleHttp\Client::class);
+        $clientMock = m::mock(Client::class);
         $clientMock->shouldReceive('get')->with('http://foo.bar/dasLamm', ['http_errors' => false])
             ->andThrow(Exception::class);
 
-        $this->instance = new RemoteTemplateFinder(
-            $fileSystemMock,
-            $config,
-            $clientMock
-        );
+        $this->instance = new RemoteTemplateFinder($fileSystemMock, $config, $clientMock);
 
-        $this->expectException(\Schnoop\RemoteTemplate\Exceptions\RemoteTemplateNotFoundException::class);
+        $this->expectException(RemoteTemplateNotFoundException::class);
         $this->instance->findRemotePathView('remote:specific::dasLamm');
     }
 
-    public function testRequestWithAdditionalOptions()
+    public function test_request_with_additional_options(): void
     {
         $hosts = [
             'specific' => [
@@ -351,7 +304,7 @@ class RemoteTemplateFinderTest extends TestCase
         $config->shouldReceive('get')->with('remote-view.ignore-urls')->andReturn([]);
         $config->shouldReceive('get')->with('remote-view.view-folder')->andReturn('tests/');
 
-        $responseMock = m::mock(\GuzzleHttp\Psr7\Response::class);
+        $responseMock = m::mock(Response::class);
         $responseMock->shouldReceive('getStatusCode')->andReturn(200);
         $responseMock->shouldReceive('getBody->getContents')->andReturn('MyContent');
 
@@ -359,20 +312,22 @@ class RemoteTemplateFinderTest extends TestCase
         $fileSystemMock->shouldReceive('exists')->with('tests/specific/daslamm.blade.php')->andReturn(true);
         $fileSystemMock->shouldReceive('put')->with('tests/specific/daslamm.blade.php', 'MyContent');
 
-        $clientMock = m::mock(\GuzzleHttp\Client::class);
-        $clientMock->shouldReceive('get')->with('http://foo.bar/dasLamm', ['auth_user' => 't', 'auth_password' => '', 'http_errors' => false])
+        $clientMock = m::mock(Client::class);
+        $clientMock->shouldReceive('get')->with(
+            'http://foo.bar/dasLamm',
+            ['auth_user' => 't', 'auth_password' => '', 'http_errors' => false],
+        )
             ->andReturn($responseMock);
 
-        $this->instance = new RemoteTemplateFinder(
-            $fileSystemMock,
-            $config,
-            $clientMock
-        );
+        $this->instance = new RemoteTemplateFinder($fileSystemMock, $config, $clientMock);
 
-        $this->assertEquals('tests/specific/daslamm.blade.php', $this->instance->findRemotePathView('remote:specific::dasLamm'));
+        $this->assertSame(
+            'tests/specific/daslamm.blade.php',
+            $this->instance->findRemotePathView('remote:specific::dasLamm'),
+        );
     }
 
-    public function testWithModifyTemplateUrlCallback()
+    public function test_with_modify_template_url_callback(): void
     {
         $hosts = [
             'specific' => [
@@ -391,7 +346,7 @@ class RemoteTemplateFinderTest extends TestCase
         $config->shouldReceive('get')->with('remote-view.ignore-urls')->andReturn([]);
         $config->shouldReceive('get')->with('remote-view.view-folder')->andReturn('tests/');
 
-        $responseMock = m::mock(\GuzzleHttp\Psr7\Response::class);
+        $responseMock = m::mock(Response::class);
         $responseMock->shouldReceive('getStatusCode')->andReturn(200);
         $responseMock->shouldReceive('getBody->getContents')->andReturn('MyContent');
 
@@ -399,23 +354,23 @@ class RemoteTemplateFinderTest extends TestCase
         $fileSystemMock->shouldReceive('exists')->with('tests/specific/daslamm.blade.php')->andReturn(true);
         $fileSystemMock->shouldReceive('put')->with('tests/specific/hurz.blade.php', 'MyContent');
 
-        $clientMock = m::mock(\GuzzleHttp\Client::class);
-        $clientMock->shouldReceive('get')->with('http://foo.bar/hurz', ['auth_user' => 't', 'auth_password' => '', 'http_errors' => false])
+        $clientMock = m::mock(Client::class);
+        $clientMock->shouldReceive('get')->with(
+            'http://foo.bar/hurz',
+            ['auth_user' => 't', 'auth_password' => '', 'http_errors' => false],
+        )
             ->andReturn($responseMock);
 
-        $this->instance = new RemoteTemplateFinder(
-            $fileSystemMock,
-            $config,
-            $clientMock
-        );
-        $this->instance->setModifyTemplateUrlCallback(function ($url) {
-            return 'hurz';
-        });
+        $this->instance = new RemoteTemplateFinder($fileSystemMock, $config, $clientMock);
+        $this->instance->setModifyTemplateUrlCallback(fn ($url) => 'hurz');
 
-        $this->assertEquals('tests/specific/hurz.blade.php', $this->instance->findRemotePathView('remote:specific::dasLamm'));
+        $this->assertSame(
+            'tests/specific/hurz.blade.php',
+            $this->instance->findRemotePathView('remote:specific::dasLamm'),
+        );
     }
 
-    public function testWithResponseHandler()
+    public function test_with_response_handler(): void
     {
         $hosts = [
             'specific' => [
@@ -434,7 +389,7 @@ class RemoteTemplateFinderTest extends TestCase
         $config->shouldReceive('get')->with('remote-view.ignore-urls')->andReturn([]);
         $config->shouldReceive('get')->with('remote-view.view-folder')->andReturn('tests/');
 
-        $responseMock = m::mock(\GuzzleHttp\Psr7\Response::class);
+        $responseMock = m::mock(Response::class);
         $responseMock->shouldReceive('getStatusCode')->andReturn(404);
         $responseMock->shouldReceive('getBody->getContents')->andReturn('MyContent');
 
@@ -442,23 +397,23 @@ class RemoteTemplateFinderTest extends TestCase
         $fileSystemMock->shouldReceive('exists')->with('tests/specific/daslamm.blade.php')->andReturn(true);
         $fileSystemMock->shouldReceive('put')->with('tests/specific/daslamm.blade.php', 'Blubb');
 
-        $clientMock = m::mock(\GuzzleHttp\Client::class);
-        $clientMock->shouldReceive('get')->with('http://foo.bar/dasLamm', ['auth_user' => 't', 'auth_password' => '', 'http_errors' => false])
+        $clientMock = m::mock(Client::class);
+        $clientMock->shouldReceive('get')->with(
+            'http://foo.bar/dasLamm',
+            ['auth_user' => 't', 'auth_password' => '', 'http_errors' => false],
+        )
             ->andReturn($responseMock);
 
-        $this->instance = new RemoteTemplateFinder(
-            $fileSystemMock,
-            $config,
-            $clientMock
-        );
-        $this->instance->pushResponseHandler(404, function () {
-            return new \Illuminate\Http\Response('Blubb', 404);
-        });
+        $this->instance = new RemoteTemplateFinder($fileSystemMock, $config, $clientMock);
+        $this->instance->pushResponseHandler(404, fn () => new IlluminateResponse('Blubb', 404));
 
-        $this->assertEquals('tests/specific/daslamm.blade.php', $this->instance->findRemotePathView('remote:specific::dasLamm'));
+        $this->assertSame(
+            'tests/specific/daslamm.blade.php',
+            $this->instance->findRemotePathView('remote:specific::dasLamm'),
+        );
     }
 
-    public function testWithResponseHandlersArray()
+    public function test_with_response_handlers_array(): void
     {
         $hosts = [
             'specific' => [
@@ -477,7 +432,7 @@ class RemoteTemplateFinderTest extends TestCase
         $config->shouldReceive('get')->with('remote-view.ignore-urls')->andReturn([]);
         $config->shouldReceive('get')->with('remote-view.view-folder')->andReturn('tests/');
 
-        $responseMock = m::mock(\GuzzleHttp\Psr7\Response::class);
+        $responseMock = m::mock(Response::class);
         $responseMock->shouldReceive('getStatusCode')->andReturn(405);
         $responseMock->shouldReceive('getBody->getContents')->andReturn('MyContent');
 
@@ -485,81 +440,68 @@ class RemoteTemplateFinderTest extends TestCase
         $fileSystemMock->shouldReceive('exists')->with('tests/specific/daslamm.blade.php')->andReturn(true);
         $fileSystemMock->shouldReceive('put')->with('tests/specific/daslamm.blade.php', 'Blubb');
 
-        $clientMock = m::mock(\GuzzleHttp\Client::class);
-        $clientMock->shouldReceive('get')->with('http://foo.bar/dasLamm', ['auth_user' => 't', 'auth_password' => '', 'http_errors' => false])
+        $clientMock = m::mock(Client::class);
+        $clientMock->shouldReceive('get')->with(
+            'http://foo.bar/dasLamm',
+            ['auth_user' => 't', 'auth_password' => '', 'http_errors' => false],
+        )
             ->andReturn($responseMock);
 
-        $this->instance = new RemoteTemplateFinder(
-            $fileSystemMock,
-            $config,
-            $clientMock
-        );
-        $this->instance->pushResponseHandler([405], function () {
-            return new \Illuminate\Http\Response('Blubb', 405);
-        });
+        $this->instance = new RemoteTemplateFinder($fileSystemMock, $config, $clientMock);
+        $this->instance->pushResponseHandler([405], fn () => new IlluminateResponse('Blubb', 405));
 
-        $this->assertEquals('tests/specific/daslamm.blade.php', $this->instance->findRemotePathView('remote:specific::dasLamm'));
+        $this->assertSame(
+            'tests/specific/daslamm.blade.php',
+            $this->instance->findRemotePathView('remote:specific::dasLamm'),
+        );
     }
 
-    public function testUrlIsOnDefaultHostForbiddenList()
+    public function test_url_is_on_default_host_forbidden_list(): void
     {
         $hosts = [
             'default' => [
-                'ignore-urls' => [
-                    'typo3',
-                ],
+                'ignore-urls' => ['typo3'],
             ],
         ];
 
         $ignoreUrlList = [
-            //'/typo3/index.php',
-            //'typo3',
+            // '/typo3/index.php',
+            // 'typo3',
         ];
 
         $config = $this->getConfigMock();
         $config->shouldReceive('get')->with('remote-view.hosts')->andReturn($hosts);
         $config->shouldReceive('get')->with('remote-view.ignore-url-suffix')->andReturn([]);
         $config->shouldReceive('get')->with('remote-view.ignore-urls')->andReturn($ignoreUrlList);
-        $this->instance = new RemoteTemplateFinder(
-            $this->getFilesystemMock(),
-            $config,
-            m::mock(\GuzzleHttp\Client::class)
-        );
+        $this->instance = new RemoteTemplateFinder($this->getFilesystemMock(), $config, m::mock(Client::class));
 
         $this->expectException(UrlIsForbiddenException::class);
         $this->expectExceptionMessage('URL # typo3/ is forbidden.');
         $this->instance->findRemotePathView('remote:typo3/');
     }
 
-    public function testUrlIsOnGeneralHostForbiddenList()
+    public function test_url_is_on_general_host_forbidden_list(): void
     {
         $hosts = [
             'default' => [
-                'ignore-urls' => [
-                ],
+                'ignore-urls' => [],
             ],
         ];
 
-        $ignoreUrlList = [
-            'typo3',
-        ];
+        $ignoreUrlList = ['typo3'];
 
         $config = $this->getConfigMock();
         $config->shouldReceive('get')->with('remote-view.hosts')->andReturn($hosts);
         $config->shouldReceive('get')->with('remote-view.ignore-url-suffix')->andReturn([]);
         $config->shouldReceive('get')->with('remote-view.ignore-urls')->andReturn($ignoreUrlList);
-        $this->instance = new RemoteTemplateFinder(
-            $this->getFilesystemMock(),
-            $config,
-            m::mock(\GuzzleHttp\Client::class)
-        );
+        $this->instance = new RemoteTemplateFinder($this->getFilesystemMock(), $config, m::mock(Client::class));
 
         $this->expectException(UrlIsForbiddenException::class);
         $this->expectExceptionMessage('URL # typo3 is forbidden.');
         $this->instance->findRemotePathView('remote:typo3');
     }
 
-    public function testWithDifferentViewFile()
+    public function test_with_different_view_file(): void
     {
         $hosts = [
             'specific' => [
@@ -578,7 +520,7 @@ class RemoteTemplateFinderTest extends TestCase
         $config->shouldReceive('get')->with('remote-view.ignore-urls')->andReturn([]);
         $config->shouldReceive('get')->with('remote-view.view-folder')->andReturn('tests/');
 
-        $responseMock = m::mock(\GuzzleHttp\Psr7\Response::class);
+        $responseMock = m::mock(Response::class);
         $responseMock->shouldReceive('getStatusCode')->andReturn(200);
         $responseMock->shouldReceive('getBody->getContents')->andReturn('MyContent');
 
@@ -586,19 +528,38 @@ class RemoteTemplateFinderTest extends TestCase
         $fileSystemMock->shouldReceive('exists')->with('tests/specific/dong.blade.php')->andReturn(true);
         $fileSystemMock->shouldReceive('put')->with('tests/specific/dong.blade.php', 'MyContent');
 
-        $clientMock = m::mock(\GuzzleHttp\Client::class);
-        $clientMock->shouldReceive('get')->with('http://foo.bar/dasLamm', ['auth_user' => 't', 'auth_password' => '', 'http_errors' => false])
+        $clientMock = m::mock(Client::class);
+        $clientMock->shouldReceive('get')->with(
+            'http://foo.bar/dasLamm',
+            ['auth_user' => 't', 'auth_password' => '', 'http_errors' => false],
+        )
             ->andReturn($responseMock);
 
-        $this->instance = new RemoteTemplateFinder(
-            $fileSystemMock,
-            $config,
-            $clientMock
-        );
-        $this->instance->setViewFilenameCallback(function ($url) {
-            return 'dong.blade.php';
-        });
+        $this->instance = new RemoteTemplateFinder($fileSystemMock, $config, $clientMock);
+        $this->instance->setViewFilenameCallback(fn ($url) => 'dong.blade.php');
 
-        $this->assertEquals('tests/specific/dong.blade.php', $this->instance->findRemotePathView('remote:specific::dasLamm'));
+        $this->assertSame(
+            'tests/specific/dong.blade.php',
+            $this->instance->findRemotePathView('remote:specific::dasLamm'),
+        );
+    }
+
+    /**
+     * @return m\MockInterface
+     */
+    private function getFilesystemMock()
+    {
+        return m::mock(Filesystem::class);
+    }
+
+    /**
+     * @return m\MockInterface
+     */
+    private function getConfigMock()
+    {
+        $config = m::mock(Repository::class);
+        $config->shouldReceive('get')->with('remote-view.remote-delimiter')->andReturn('remote:');
+
+        return $config;
     }
 }

--- a/tlint.json
+++ b/tlint.json
@@ -1,0 +1,3 @@
+{
+    "preset": "Chiiya\\LaravelCodeStyle\\TLintPreset"
+}


### PR DESCRIPTION
- Use [chiiya/laravel-code-style](https://github.com/chiiya/laravel-code-style) instead of (outdated version of) [chiiya/code-style-php](https://github.com/chiiya/code-style-php)
- Update Github actions
- Require at least PHP 8.1 (is this an issue?). If we need to support PHP 8.0 we'd just need to disable some Rector rules.

Can't figure out how to run tests. `phpunit.xml.dist` seems to be missing as well?