### PR TITLE
Fix response handler

### DIFF
--- a/src/View/RemoteTemplateFinder.php
+++ b/src/View/RemoteTemplateFinder.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Schnoop\RemoteTemplate\View;
 

--- a/src/View/RemoteTemplateFinder.php
+++ b/src/View/RemoteTemplateFinder.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Schnoop\RemoteTemplate\View;
 
@@ -118,7 +120,7 @@ class RemoteTemplateFinder
     public function fetchContentFromRemoteHost(
         string $url,
         array $remoteHost,
-    ): IlluminateResponse|Response|ResponseInterface {
+    ): IlluminateResponse|Response|ResponseInterface|string {
         $options = [
             'http_errors' => false,
         ];
@@ -252,7 +254,7 @@ class RemoteTemplateFinder
     protected function callResponseHandler(
         ResponseInterface $result,
         array $remoteHost,
-    ): IlluminateResponse|Response|ResponseInterface {
+    ): IlluminateResponse|Response|ResponseInterface|string {
         if (isset($this->handler[$result->getStatusCode()])
             && is_callable($this->handler[$result->getStatusCode()])
         ) {


### PR DESCRIPTION
Use case: we use the `pushResponseHandler` method to define a custom response handler that does some string replacements
on the final response. This means we return a string instead of a response. Since the value returned by the function is casted to a string anyways, it should be able to return a string directly without any issues.

```php
        $this->app->make('remoteview.finder')->pushResponseHandler(
            200,
            fn (Response $result, array $config, RemoteTemplateFinder $service) => str_replace(
                [
                    'https://example.org',
                ],
                trim(url()->to('/'), '/'),
                $result->getBody()->getContents(),
            )
        );
```